### PR TITLE
More robust error handling

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,10 +1,10 @@
 ---
 cog_bundle_version: 3
 name: pingdom
-version: 0.0.13
+version: 0.0.16
 docker:
   image: cogcmd/pingdom
-  tag: 0.0.13
+  tag: 0.0.16
 permissions:
   - pingdom:check
 commands:

--- a/lib/cog_cmd/pingdom/check.rb
+++ b/lib/cog_cmd/pingdom/check.rb
@@ -15,7 +15,6 @@ class CogCmd::Pingdom::Check < Cog::Command
     when "show"
       args.shift
       if id = args[0]
-        id = id.to_f.to_i # TODO: Temporary hacky workaround for Go's JSON shenanigans
         api_response = make_api_request("/checks/#{id}")
         response.content = JSON.parse(api_response.body)["check"]
       else
@@ -24,9 +23,8 @@ class CogCmd::Pingdom::Check < Cog::Command
     when "results"
       args.shift
       if id = args[0]
-        id = id.to_f.to_i # TODO: Temporary hacky workaround for Go's JSON shenanigans
         limit = if count = request.options["count"]
-                  count.to_i
+                  Integer(count)
                  else
                    1
                  end
@@ -77,10 +75,9 @@ class CogCmd::Pingdom::Check < Cog::Command
       case resp
       when Net::HTTPSuccess
         resp
-      when Net::HTTPUnauthorized
-        fail("Failed to authenticate with Pingdom")
       else
-        fail("Failed: #{resp.value}")
+        error = JSON.parse(resp.body)["error"]
+        fail("Pingdom API Request Failure: #{error["statuscode"]} (#{error["statusdesc"]}) -  #{error["errormessage"]}")
       end
     end
   end


### PR DESCRIPTION
Pingdom includes enough information in their error responses that we can
use to make very useful Cog error messages. Part of this includes
whether or not a given check identifier is valid, so we don't even need
to mess with the identifier value passed to the command as an argument.

(We can also remove that conversion from a string to a float to an
integer now that Relay has updated its JSON handling.)
